### PR TITLE
BUG: Fix JupyterLab build configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,12 @@ For a development installation (requires `Node.js <https://nodejs.org/en/downloa
   jupyter nbextension enable --py --sys-prefix widgetsnbextension
   python -m pytest
 
+The above commands will setup your system for development with the Jupyter
+Notebook. To develop for Jupyter Lab, additionally run::
+
+  jupyter labextension install @jupyter-widgets/jupyterlab-manager
+  jupyter labextension install ./js
+
 .. warning::
 
   This project is under active development. Its API and behavior may change at

--- a/examples/2DImage.ipynb
+++ b/examples/2DImage.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,13 +44,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8738667272d349bba81e82e3af9284eb",
+       "model_id": "5cd80ad0009c484fa13efdc01518b414",
        "version_major": 2,
        "version_minor": 0
       },
@@ -70,7 +70,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Viewer(image=<itkImagePython.itkImageUC2; proxy of <Swig Object of type 'itkImageUC2 *' at 0x7f772f077810> >)"
+       "Viewer(image=<itkImagePython.itkImageUC2; proxy of <Swig Object of type 'itkImageUC2 *' at 0x7ff04954d720> >)"
       ]
      },
      "metadata": {},
@@ -81,6 +81,13 @@
     "image = itk.imread(file_name)\n",
     "view(image)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/js/lib/itkConfigCDN.js
+++ b/js/lib/itkConfigCDN.js
@@ -1,0 +1,5 @@
+const itkConfig = {
+  itkModulesPath: __webpack_public_path__ + '/itk'
+}
+
+module.exports = itkConfig

--- a/js/lib/viewer.js
+++ b/js/lib/viewer.js
@@ -1,8 +1,8 @@
 import 'babel-polyfill'
-import widgets from '@jupyter-widgets/base';
-import _ from 'lodash';
-import vtkITKHelper from 'vtk.js/Sources/Common/DataModel/ITKHelper';
-import createViewer from 'itk-vtk-image-viewer/src/createViewer';
+const widgets = require('@jupyter-widgets/base')
+const  _ = require('lodash')
+import vtkITKHelper from 'vtk.js/Sources/Common/DataModel/ITKHelper'
+import createViewer from 'itk-vtk-image-viewer/src/createViewer'
 import IntTypes from 'itk/IntTypes'
 import FloatTypes from 'itk/FloatTypes'
 import IOTypes from 'itk/IOTypes'

--- a/js/package.json
+++ b/js/package.json
@@ -13,10 +13,12 @@
     "widgets",
     "ipython",
     "ipywidgets",
-    "jupyterlab-extension",
     "itk",
     "imaging",
-    "visualization"
+    "visualization",
+    "webgl",
+    "jupyterlab",
+    "jupyterlab-extension"
   ],
   "files": [
     "lib/**/*.js",
@@ -42,6 +44,7 @@
     "url-loader": "^1.0.1",
     "webpack": "^4.1.1",
     "webpack-cli": "^2.0.12",
+    "webpack-node-externals": "^1.7.2",
     "worker-loader": "^2.0.0"
   },
   "dependencies": {
@@ -56,6 +59,6 @@
     "vtk.js": "6.6.1"
   },
   "jupyterlab": {
-    "extension": "lib/extension-jupyterlab"
+    "extension": "dist/labextension"
   }
 }

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,7 +1,8 @@
-var path = require('path')
-var version = require('./package.json').version
+var path = require('path');
+var version = require('./package.json').version;
 
-const CopyPlugin = require('copy-webpack-plugin')
+const CopyPlugin = require('copy-webpack-plugin');
+const nodeExternals = require('webpack-node-externals');
 
 const vtkRules = require('vtk.js/Utilities/config/rules-vtk.js');
 const commonRules = require('vtk.js/Utilities/config/rules-examples.js');
@@ -9,8 +10,9 @@ const commonRules = require('vtk.js/Utilities/config/rules-examples.js');
 // Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
 var rules = [
-  { test: /\.css$/,
-    use: ['style-loader', 'css-loader']
+  {
+    test: /\.css$/,
+    use: ['style-loader', 'css-loader'],
   },
   {
     test: /\.js$/,
@@ -18,151 +20,253 @@ var rules = [
     use: {
       loader: 'babel-loader',
       options: {
-        presets: ['env']
-      }
-    }
-  }
-].concat(vtkRules, commonRules)
-
-const maxAssetSize = 2000000
-
-
-module.exports = [
-    {// Notebook extension
-     //
-     // This bundle only contains the part of the JavaScript that is run on
-     // load of the notebook. This section generally only performs
-     // some configuration for requirejs, and provides the legacy
-     // "load_ipython_extension" function which is required for any notebook
-     // extension.
-     //
-        node: {
-          fs: 'empty',
-        },
-        entry: './lib/extension.js',
-        output: {
-            filename: 'extension.js',
-            path: path.resolve(__dirname, '..', 'itkwidgets', 'static'),
-            libraryTarget: 'amd'
-        },
-        resolve: {
-          modules: [
-            path.resolve(__dirname, 'node_modules'),
-          ],
-          alias: {
-            './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigJupyter.js'),
-          },
-        },
-        performance: {
-          maxAssetSize: maxAssetSize,
-          maxEntrypointSize: maxAssetSize
-        },
-    },
-    {// Bundle for the notebook containing the custom widget views and models
-     //
-     // This bundle contains the implementation for the custom widget views and
-     // custom widget.
-     // It must be an amd module
-     //
-        node: {
-          fs: 'empty',
-        },
-        entry: './lib/index.js',
-        output: {
-            filename: 'index.js',
-            path: path.resolve(__dirname, '..', 'itkwidgets', 'static'),
-            libraryTarget: 'amd'
-        },
-        devtool: 'source-map',
-        module: {
-            rules: rules
-        },
-        resolve: {
-          modules: [
-            path.resolve(__dirname, 'node_modules'),
-          ],
-          alias: {
-            './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigJupyter.js'),
-          },
-        },
-        plugins: [
-          new CopyPlugin([
-            {
-              from: path.join(__dirname, 'node_modules', 'itk', 'WebWorkers', 'Pipeline.worker.js'),
-              to: path.join(__dirname, '..', 'itkwidgets', 'static', 'itk', 'WebWorkers', 'Pipeline.worker.js')
-            },
-            {
-              from: path.join(__dirname, 'lib', 'ZstdDecompress', 'web-build', 'ZstdDecompress.js'),
-              to: path.join(__dirname, '..', 'itkwidgets', 'static', 'itk', 'Pipelines', 'ZstdDecompress.js')
-            },
-            {
-              from: path.join(__dirname, 'lib', 'ZstdDecompress', 'web-build', 'ZstdDecompressWasm.js'),
-              to: path.join(__dirname, '..', 'itkwidgets', 'static', 'itk', 'Pipelines', 'ZstdDecompressWasm.js')
-            },
-          ]),
-        ],
-      externals: ['@jupyter-widgets/base', {config: '{}'}],
-      performance: {
-        maxAssetSize: maxAssetSize,
-        maxEntrypointSize: maxAssetSize
+        presets: ['env'],
       },
     },
-    {// Embeddable itk-jupyter-widgets bundle
-     //
-     // This bundle is generally almost identical to the notebook bundle
-     // containing the custom widget views and models.
-     //
-     // The only difference is in the configuration of the webpack public path
-     // for the static assets.
-     //
-     // It will be automatically distributed by unpkg to work with the static
-     // widget embedder.
-     //
-     // The target bundle is always `dist/index.js`, which is the path required
-     // by the custom widget embedder.
-     //
-        node: {
-          fs: 'empty',
+  },
+].concat(vtkRules, commonRules);
+
+const resolve = {
+  modules: [path.resolve(__dirname, 'node_modules')],
+  alias: {
+    './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigJupyter.js'),
+  },
+};
+
+const maxAssetSize = 2000000;
+const performance = {
+  maxAssetSize: maxAssetSize,
+  maxEntrypointSize: maxAssetSize,
+};
+
+module.exports = [
+  {
+    // Notebook extension
+    //
+    // This bundle only contains the part of the JavaScript that is run on
+    // load of the notebook. This section generally only performs
+    // some configuration for requirejs, and provides the legacy
+    // "load_ipython_extension" function which is required for any notebook
+    // extension.
+    //
+    node: {
+      fs: 'empty',
+    },
+    entry: './lib/extension.js',
+    output: {
+      filename: 'extension.js',
+      path: path.resolve(__dirname, '..', 'itkwidgets', 'static'),
+      libraryTarget: 'amd',
+    },
+    resolve,
+    performance,
+  },
+  {
+    // Bundle for the notebook containing the custom widget views and models
+    //
+    // This bundle contains the implementation for the custom widget views and
+    // custom widget.
+    // It must be an amd module
+    //
+    node: {
+      fs: 'empty',
+    },
+    entry: './lib/index.js',
+    output: {
+      filename: 'index.js',
+      path: path.resolve(__dirname, '..', 'itkwidgets', 'static'),
+      libraryTarget: 'amd',
+    },
+    devtool: 'source-map',
+    module: {
+      rules: rules,
+    },
+    resolve,
+    plugins: [
+      new CopyPlugin([
+        {
+          from: path.join(
+            __dirname,
+            'node_modules',
+            'itk',
+            'WebWorkers',
+            'Pipeline.worker.js'
+          ),
+          to: path.join(
+            __dirname,
+            '..',
+            'itkwidgets',
+            'static',
+            'itk',
+            'WebWorkers',
+            'Pipeline.worker.js'
+          ),
         },
-        entry: './lib/embed.js',
-        output: {
-            filename: 'index.js',
-            path: path.resolve(__dirname, 'dist'),
-            libraryTarget: 'amd',
-            publicPath: 'https://unpkg.com/itk-jupyter-widgets@' + version + '/dist/'
+        {
+          from: path.join(
+            __dirname,
+            'lib',
+            'ZstdDecompress',
+            'web-build',
+            'ZstdDecompress.js'
+          ),
+          to: path.join(
+            __dirname,
+            '..',
+            'itkwidgets',
+            'static',
+            'itk',
+            'Pipelines',
+            'ZstdDecompress.js'
+          ),
         },
-        devtool: 'source-map',
-        module: {
-            rules: rules
+        {
+          from: path.join(
+            __dirname,
+            'lib',
+            'ZstdDecompress',
+            'web-build',
+            'ZstdDecompressWasm.js'
+          ),
+          to: path.join(
+            __dirname,
+            '..',
+            'itkwidgets',
+            'static',
+            'itk',
+            'Pipelines',
+            'ZstdDecompressWasm.js'
+          ),
         },
-        resolve: {
-          modules: [
-            path.resolve(__dirname, 'node_modules'),
-          ],
-          alias: {
-            './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigJupyter.js'),
-          },
+      ]),
+    ],
+    externals: ['@jupyter-widgets/base'],
+    performance,
+  },
+  {
+    // Embeddable itk-jupyter-widgets bundle
+    //
+    // This bundle is generally almost identical to the notebook bundle
+    // containing the custom widget views and models.
+    //
+    // The only difference is in the configuration of the webpack public path
+    // for the static assets.
+    //
+    // It will be automatically distributed by unpkg to work with the static
+    // widget embedder.
+    //
+    // The target bundle is always `dist/index.js`, which is the path required
+    // by the custom widget embedder.
+    //
+    node: {
+      fs: 'empty',
+    },
+    entry: './lib/embed.js',
+    output: {
+      filename: 'index.js',
+      path: path.resolve(__dirname, 'dist'),
+      libraryTarget: 'amd',
+      publicPath: 'https://unpkg.com/itk-jupyter-widgets@' + version + '/dist',
+    },
+    devtool: 'source-map',
+    module: {
+      rules: rules,
+    },
+    resolve: {
+      modules: [path.resolve(__dirname, 'node_modules')],
+      alias: {
+        './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigCDN.js'),
+      },
+    },
+    plugins: [
+      new CopyPlugin([
+        {
+          from: path.join(
+            __dirname,
+            'node_modules',
+            'itk',
+            'WebWorkers',
+            'Pipeline.worker.js'
+          ),
+          to: path.join(
+            __dirname,
+            'dist',
+            'itk',
+            'WebWorkers',
+            'Pipeline.worker.js'
+          ),
         },
-        plugins: [
-          new CopyPlugin([
-            {
-              from: path.join(__dirname, 'node_modules', 'itk', 'WebWorkers', 'Pipeline.worker.js'),
-              to: path.join(__dirname, 'dist', 'itk', 'WebWorkers', 'Pipeline.worker.js')
-            },
-            {
-              from: path.join(__dirname, 'lib', 'ZstdDecompress', 'web-build', 'ZstdDecompress.js'),
-              to: path.join(__dirname, 'dist', 'itk', 'Pipelines', 'ZstdDecompress.js')
-            },
-            {
-              from: path.join(__dirname, 'lib', 'ZstdDecompress', 'web-build', 'ZstdDecompressWasm.js'),
-              to: path.join(__dirname, 'dist', 'itk', 'Pipelines', 'ZstdDecompressWasm.js')
-            },
-          ]),
+        {
+          from: path.join(
+            __dirname,
+            'lib',
+            'ZstdDecompress',
+            'web-build',
+            'ZstdDecompress.js'
+          ),
+          to: path.join(
+            __dirname,
+            'dist',
+            'itk',
+            'Pipelines',
+            'ZstdDecompress.js'
+          ),
+        },
+        {
+          from: path.join(
+            __dirname,
+            'lib',
+            'ZstdDecompress',
+            'web-build',
+            'ZstdDecompressWasm.js'
+          ),
+          to: path.join(
+            __dirname,
+            'dist',
+            'itk',
+            'Pipelines',
+            'ZstdDecompressWasm.js'
+          ),
+        },
+      ]),
+    ],
+    externals: ['@jupyter-widgets/base'],
+    performance,
+  },
+  {
+    // Bundle for JupyterLab
+    //
+    // This bundle externalizes dependencies so we can build with our webpack
+    // rules.
+    //
+    node: {
+      fs: 'empty',
+    },
+    entry: './lib/extension-jupyterlab.js',
+    output: {
+      filename: 'labextension.js',
+      path: path.resolve(__dirname, 'dist'),
+      libraryTarget: 'amd',
+      publicPath: 'https://unpkg.com/itk-jupyter-widgets@' + version + '/dist',
+    },
+    devtool: 'source-map',
+    module: {
+      rules: rules,
+    },
+    resolve: {
+      modules: [path.resolve(__dirname, 'node_modules')],
+      alias: {
+        './itkConfig$': path.resolve(__dirname, 'lib', 'itkConfigCDN.js'),
+      },
+    },
+    externals: [
+      nodeExternals({
+        whitelist: [
+          /^vtk.js[\/].*/,
+          /^itk[\/].*/,
+          /^itk-vtk-image-viewer[\/].*/,
         ],
-        externals: ['@jupyter-widgets/base', {config: '{}'}],
-        performance: {
-          maxAssetSize: maxAssetSize,
-          maxEntrypointSize: maxAssetSize
-        },
-    }
+      }),
+    ],
+  },
 ];

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ class NPM(Command):
 
     targets = [
         os.path.join(here, 'itkwidgets', 'static', 'extension.js'),
-        os.path.join(here, 'itkwidgets', 'static', 'index.js')
+        os.path.join(here, 'itkwidgets', 'static', 'index.js'),
+        os.path.join(here, 'js', 'dist', 'labextension.js')
     ]
 
     def initialize_options(self):
@@ -170,7 +171,12 @@ setup_args = {
     'keywords': [
         'ipython',
         'jupyter',
+        'jupyterlab-extension',
         'widgets',
+        'itk',
+        'imaging',
+        'visualization',
+        'webgl',
     ],
     'classifiers': [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Pre-build the labextension with webpack so we can use the webpack rules
required for vtk.js and the custom webpack configuration for itk.js.
This is achieved by whitelisting the modules from being excluded by the
webpack-node-externals package.

Use the Unpkg CDN to provide the WebAssembly and WebWorker files loaded
dynamically.

Thanks to @saulshanabrook and @vidartf for the suggestions on how to address this issue.

Addresses #11 