### PR TITLE
ENH: Use ipydatawidgets for roi traitlet

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -59,6 +59,7 @@
     "css-element-queries": "^1.0.2",
     "itk": "^9.1.1",
     "itk-vtk-viewer": "^6.4.1",
+    "jupyter-dataserializers": "^1.2.0",
     "lodash": "^4.17.5",
     "vtk.js": "7.6.0"
   },

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ setup_args = {
     ],
     'install_requires': [
         'itk-core>=4.13.1',
+        'ipydatawidgets>=3.0.0',
         'ipywidgets>=7.4.0',
         'numpy',
         'six',


### PR DESCRIPTION
@vidarf I am trying to use `ipydatawidgets` for a 2D float array that specifies a region of interest.

However, the change in the JavaScript model does not appear to be propagated to the Python kernel side. This is evident by the `viewer.roi_region()` still being all zeros in [this example notebook](https://github.com/InsightSoftwareConsortium/itk-jupyter-widgets/blob/master/examples/SelectRegionOfInterest.ipynb).

An ideas on what needs to change?