### PR TITLE
BUG: Work around gradient opacity persistence

### DIFF
--- a/js/lib/viewer.js
+++ b/js/lib/viewer.js
@@ -67,7 +67,10 @@ const resetVolumeRenderingStatus = (domWidgetView) => {
       // Why is this necessary?
       const shadow = domWidgetView.model.get('shadow')
       representation.setUseShadow(shadow);
-      if (viewProxy.getViewMode() == 'VolumeRendering') {
+      const gradientOpacity = domWidgetView.model.get('gradient_opacity')
+      // Todo: Fix this in vtk.js
+      representation.setEdgeGradient(representation.getEdgeGradient() + 1e-7)
+      if (viewProxy.getViewMode() === 'VolumeRendering') {
         viewProxy.resetCamera()
       }
       domWidgetView.model.set('_volume_rendering_image', false)


### PR DESCRIPTION
When `.setImage` is called on the view proxy, the edge gradient value is
not used in the updated rendering.

Work around this by slightly tweaking the edge gradient value, which
causes it to be used.

This probably needs to be addressed somewhere in vtk.js at some point.