### PR TITLE
BUG: Correct sdist paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,7 @@ class NPM(Command):
 
     targets = [
         os.path.join(here, 'itkwidgets', 'static', 'extension.js'),
-        os.path.join(here, 'itkwidgets', 'static', 'index.js'),
-        os.path.join(here, 'js', 'dist', 'labextension.js')
+        os.path.join(here, 'itkwidgets', 'static', 'index.js')
     ]
 
     def initialize_options(self):
@@ -140,7 +139,7 @@ setup_args = {
             'itkwidgets/static/index.js',
             'itkwidgets/static/index.js.map'
         ],),
-        ('etc/jupyter/nbconfig/notebook.d/' , ['itk-jupyter-widgets.json']),
+        ('etc/jupyter/nbconfig/notebook.d' , ['itk-jupyter-widgets.json']),
         ('share/jupyter/nbextensions/itk-jupyter-widgets/itk/Pipelines', [
 	    'itkwidgets/static/itk/Pipelines/ZstdDecompressWasm.js',
             'itkwidgets/static/itk/Pipelines/ZstdDecompress.js',


### PR DESCRIPTION
Without this, the Conda build fails because the .js/ folder is missing.