### PR TITLE
BUG: Always set the downsampling filter input image

### DIFF
--- a/itkwidgets/widget_viewer.py
+++ b/itkwidgets/widget_viewer.py
@@ -295,6 +295,7 @@ class Viewer(ViewerParent):
             else:
                 scale_factors = self._find_scale_factors(self.size_limit_3d, dimension, size)
             self._scale_factors = np.array(scale_factors, dtype=np.uint8)
+            self.shrinker.SetInput(self.image)
             self.shrinker.SetShrinkFactors(scale_factors[:dimension])
 
             region = itk.ImageRegion[dimension]()
@@ -305,6 +306,7 @@ class Viewer(ViewerParent):
             region.PadByRadius(1)
             region.Crop(self.image.GetLargestPossibleRegion())
 
+            self.extractor.SetInput(self.image)
             self.extractor.SetExtractionRegion(region)
 
             size = region.GetSize()


### PR DESCRIPTION
When performing interactive parameter exploration, the input image can
change.

@phcerdan this hopefully addresses the issue reported!