### PR TITLE
Extract geometry for most non-PolyData VTK types

### DIFF
--- a/itkwidgets/_transform_types.py
+++ b/itkwidgets/_transform_types.py
@@ -294,7 +294,9 @@ def to_geometry(geometry_like):
             geometry['cellData'] = cell_data
 
         return geometry
-    elif have_vtk and isinstance(geometry_like, vtk.vtkUnstructuredGrid):
+    elif have_vtk and isinstance(geometry_like, (vtk.vtkUnstructuredGrid, 
+                                                 vtk.vtkStructuredGrid, 
+                                                 vtk.vtkRectilinearGrid)):
         geometry_filter = vtk.vtkGeometryFilter()
         geometry_filter.SetInputData(geometry_like)
         geometry_filter.Update()


### PR DESCRIPTION
Inspired by https://github.com/InsightSoftwareConsortium/itk-jupyter-widgets/pull/177#issuecomment-515263169

This makes it so users can pass most VTK mesh types:

- `vtkPolyData` / `pyvista.PolyData`
- `vtkUnstructuredGrid` / `pyvista.UnstructuredGrid`
- `vtkStructuredGrid` / `pyvista.StructuredGrid`
- `vtkRectilinearGrid` / `pyvista.RectilinearGrid` - can't this be volume rendered by VTKjs? maybe this should be handled differently?

and have those meshes' geometries extracted and viewed by `itkwidgets` without issue or confusion.

Lingering question - should we add `vtkImageData` here as well incase a user wants to treat the image data like geometry and not a volume (i.e. just plot the bounding surface)?

cc @thewtex 